### PR TITLE
Rewrite get moodle files using bfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moodle-dl-ext",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "packageManager": "yarn@3.2.4",
   "description": "Moodle downloader extension for Chrome",
   "private": true,

--- a/packages/content-script/package.json
+++ b/packages/content-script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moodle-dl-ext/content-script",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "scripts": {
     "pre-build": "rm -rf build dist && mkdir -p build dist",

--- a/packages/content-script/src/moodle-files.ts
+++ b/packages/content-script/src/moodle-files.ts
@@ -92,20 +92,27 @@ const resourceUrlsFound = new Set<string>();
 
 export async function getMoodleFiles(initialResource: Resource): Promise<PartialMoodleFile[]> {
   crawlingQueue.push([initialResource, '']);
-  let moodleFiles: PartialMoodleFile[] = [];
+  const moodleFiles: PartialMoodleFile[] = [];
 
   while (crawlingQueue.length > 0) {
-    let [currentResource, currentPath] = crawlingQueue.shift()!;
+    const pair = crawlingQueue.at(0)!;
+    const currentResource = pair[0];
+    let currentPath = pair[1];
+    crawlingQueue.shift();
+
     const url = getUrlWithoutHashtag(currentResource.url);
 
     const { name, type } = currentResource;
 
     if (['courseView'].includes(type)) {
-      crawlingQueue.push([{
-        name: 'course view',
-        type: 'courseResources',
-        url: url.replace('view', 'resources')
-      }, '']);
+      crawlingQueue.push([
+        {
+          name: 'course view',
+          type: 'courseResources',
+          url: url.replace('view', 'resources')
+        },
+        ''
+      ]);
     } else if (['courseResources', 'modFolderView'].includes(type)) {
       message<string>('status-log', `Processing ${url}`);
 
@@ -147,7 +154,7 @@ export async function getMoodleFiles(initialResource: Resource): Promise<Partial
         sourceUrl: url,
         filenamePrefix: currentPath
       };
-      console.log(partialMoodleFile);
+
       moodleFiles.push(partialMoodleFile);
     } else {
       throw new Error(`Unknown resource type '${type}'!`);

--- a/packages/content-script/src/moodle-files.ts
+++ b/packages/content-script/src/moodle-files.ts
@@ -1,4 +1,4 @@
-import JSZip, { file } from 'jszip';
+import JSZip from 'jszip';
 import { message } from './message';
 import { randStr } from './util';
 
@@ -87,69 +87,74 @@ function getUrlWithoutHashtag(url: string): string {
   return url.split('#')[0];
 }
 
-export const processedResourceUrls = new Set<string>();
+const crawlingQueue: [Resource, string][] = [];
+const resourceUrlsFound = new Set<string>();
 
-export async function getMoodleFiles(resource: Resource, filenamePrefix = ''): Promise<PartialMoodleFile[]> {
-  const url = getUrlWithoutHashtag(resource.url);
-  const { name, type } = resource;
-  if (processedResourceUrls.has(url)) {
-    return [];
-  }
-  processedResourceUrls.add(url);
+export async function getMoodleFiles(initialResource: Resource): Promise<PartialMoodleFile[]> {
+  crawlingQueue.push([initialResource, '']);
+  let moodleFiles: PartialMoodleFile[] = [];
 
-  if (['courseView'].includes(type)) {
-    return getMoodleFiles({
-      name: 'course view',
-      type: 'courseResources',
-      url: url.replace('view', 'resources')
-    });
-  } else if (['courseResources', 'modFolderView'].includes(type)) {
-    message<string>('status-log', `Processing ${url}`);
+  while (crawlingQueue.length > 0) {
+    let [currentResource, currentPath] = crawlingQueue.shift()!;
+    const url = getUrlWithoutHashtag(currentResource.url);
 
-    const response = await fetch(url);
-    const domParser = new DOMParser();
-    const document = domParser.parseFromString(await response.text(), 'text/html').documentElement;
-    const urls = document.getElementsByTagName('a');
-    let moodleFiles: PartialMoodleFile[] = [];
+    const { name, type } = currentResource;
 
-    let pagePrefix = filenamePrefix;
-    if (['courseResources'].includes(type)) {
-      const title = document.getElementsByTagName('title')[0].innerText;
-      const processedTitle = title ? getValidFilename(title) : '';
-      pagePrefix += processedTitle + '/';
-    }
+    if (['courseView'].includes(type)) {
+      crawlingQueue.push([{
+        name: 'course view',
+        type: 'courseResources',
+        url: url.replace('view', 'resources')
+      }, '']);
+    } else if (['courseResources', 'modFolderView'].includes(type)) {
+      message<string>('status-log', `Processing ${url}`);
 
-    const localProcessedResourceUrls = new Set<string>();
-    for (const url of urls) {
-      const urlWithoutHashtag = getUrlWithoutHashtag(url.href);
-      if (localProcessedResourceUrls.has(urlWithoutHashtag) || processedResourceUrls.has(urlWithoutHashtag)) {
-        continue;
+      const response = await fetch(url);
+      const domParser = new DOMParser();
+      const document = domParser.parseFromString(await response.text(), 'text/html');
+      const page = document.getElementById('page');
+      // Get urls from the elememt with id 'page' first to narrow down the list of urls
+      const urls = page?.getElementsByTagName('a') ?? document.getElementsByTagName('a');
+
+      if (type === 'courseResources') {
+        const title = document.getElementsByTagName('title')[0].innerText;
+        const processedTitle = title ? getValidFilename(title) : '';
+        currentPath += processedTitle + '/';
       }
-      localProcessedResourceUrls.add(urlWithoutHashtag);
 
-      const targetResource = convertUrlToResource(url);
-      // The second condition prevents from crawling back to other courses.
-      if (targetResource && targetResource.type !== 'courseView') {
-        let finalPrefix = pagePrefix;
-        if (targetResource.type === 'modFolderView') {
-          finalPrefix += urlToFilename(url.innerText) + '/';
+      for (const url of urls) {
+        const urlWithoutHashtag = getUrlWithoutHashtag(url.href);
+        const targetResource = convertUrlToResource(url);
+
+        // Skip urls that are not valid resources or have already been processed
+        if (!targetResource || resourceUrlsFound.has(urlWithoutHashtag)) {
+          continue;
         }
-        moodleFiles = moodleFiles.concat(await getMoodleFiles(targetResource, finalPrefix));
-      }
-    }
-    return moodleFiles;
-  } else if (['modResourceView', 'pluginfile'].includes(type)) {
-    message<string>('status-log', `Processing ${url}`);
-    const partialMoodleFile: PartialMoodleFile = {
-      resourceName: name,
-      sourceUrl: url,
-      filenamePrefix
-    };
 
-    return [partialMoodleFile];
-  } else {
-    throw new Error(`Unknown resource type '${type}'!`);
+        if (targetResource.type !== 'courseView') {
+          let targetPath = currentPath;
+          if (targetResource.type === 'modFolderView') {
+            targetPath += urlToFilename(url.innerText) + '/';
+          }
+          crawlingQueue.push([targetResource, targetPath]);
+          resourceUrlsFound.add(urlWithoutHashtag);
+        }
+      }
+    } else if (['modResourceView', 'pluginfile'].includes(type)) {
+      message<string>('status-log', `Processing ${url}`);
+      const partialMoodleFile: PartialMoodleFile = {
+        resourceName: name,
+        sourceUrl: url,
+        filenamePrefix: currentPath
+      };
+      console.log(partialMoodleFile);
+      moodleFiles.push(partialMoodleFile);
+    } else {
+      throw new Error(`Unknown resource type '${type}'!`);
+    }
   }
+
+  return moodleFiles;
 }
 
 export async function downloadMoodleFiles(partialMoodleFiles: PartialMoodleFile[]): Promise<MoodleFile[]> {
@@ -226,7 +231,7 @@ export async function generateZipFile(moodleFiles: MoodleFile[]): Promise<void> 
 }
 
 export function init(): void {
-  processedResourceUrls.clear();
+  resourceUrlsFound.clear();
   message('download-progress', {
     current: 0,
     total: 1

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moodle-dl-ext/popup",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.10.0",

--- a/packages/popup/public/manifest.json
+++ b/packages/popup/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Moodle Downloader",
   "description": "Download all moodle files with one click.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "manifest_version": 3,
   "permissions": ["activeTab", "scripting"],
   "action": {


### PR DESCRIPTION
Close #17 .

Previously, the crawling function `getMoodleFiles` is written using DFS. It could lead to a wrong nested folder structure if there is a previously not yet processed folder URL on the current page.

Example:

```
            folder a
            /            \
     folder b     folder c
     /           \
folder c    file x
```

In this case, folder c will be considered a child of folder b instead of being skipped. Due to the nature of DFS, it is hard to know that folder c should actually be on the same level as folder b. 

Therefore, this PR replaces the DFS implementation with BFS.